### PR TITLE
Make getDescription tolerant to null returned by getCredentials.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePassword.java
+++ b/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePassword.java
@@ -187,7 +187,12 @@ public class GoogleRobotUsernamePassword extends BaseStandardCredentials
   /** {@inheritDoc} */
   @Override
   public String getDescription() {
-    return CredentialsNameProvider.name(getCredentials());
+    final GoogleRobotCredentials credentials = getCredentials();
+    if (credentials == null) {
+      return "";
+    } else {
+      return CredentialsNameProvider.name(credentials);
+    }
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
Fix for the crash here:

FATAL: null
java.lang.NullPointerException
    at com.cloudbees.plugins.credentials.CredentialsNameProvider.name(CredentialsNameProvider.java:49)
    at com.google.jenkins.plugins.source.GoogleRobotUsernamePassword.getDescription(GoogleRobotUsernamePassword.java:190)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:1451)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$300(CliGitAPIImpl.java:64)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:315)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$1.call(RemoteGitImpl.java:152)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$1.call(RemoteGitImpl.java:145)
    at hudson.remoting.UserRequest.perform(UserRequest.java:153)
    at hudson.remoting.UserRequest.perform(UserRequest.java:50)
    at hudson.remoting.Request$2.run(Request.java:332)
