### PR TITLE
Change projecthosting scope to source.read_write scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Read more: http://wiki.jenkins-ci.org/display/JENKINS/Google+Source+Plugin
 This plugin provides the credential provider to use Google Cloud Platform OAuth Credentials (provided by the Google OAuth Plugin) to access source code from https://source.developer.google.com as well as https://*.googlesource.com. It supports both kinds of credentials provided by Google OAuth Plugin: Google Service Account from metadata as well as Google Service Account from private key.
 
 
-1. In order to use a Git repository hosted on https://source.developer.google.com, your credential will need the scope https://www.googleapis.com/auth/projecthosting.  Your service account will need to have access to the repository’s Google Cloud Platform project.
+1. In order to use a Git repository hosted on https://source.developer.google.com, your credential will need the scope https://www.googleapis.com/auth/source.read_write.  Your service account will need to have access to the repository’s Google Cloud Platform project.
 
 1. In order to use https://*.googlesource.com, your credential will need the scope https://www.googleapis.com/auth/gerritcodereview.  Your service account will need to be whitelisted by the maintainers of that repository.
 
@@ -17,7 +17,7 @@ First, configure your OAuth credentials per instructions from Google OAuth Plugi
 
 Then, when configuring the Git repository for your Jenkins job, if you enter a https://*.googlesource.com address in the “Repository URL” text area, your Credentials drop box will automatically be populated with credentials having the https://www.googleapis.com/auth/gerritcodereview scope
 
-Similarly, if you enter a https://source.developer.google.com Git repository, your Credentials box will be populated with credentials having the https://www.googleapis.com/auth/projecthosting scope.
+Similarly, if you enter a https://source.developer.google.com Git repository, your Credentials box will be populated with credentials having the https://www.googleapis.com/auth/source.read_write scope.
 
 Select the required credential, then your job is ready to go!
 

--- a/src/main/java/com/google/jenkins/plugins/source/CloudPlatformSourceScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/source/CloudPlatformSourceScopeRequirement.java
@@ -27,6 +27,6 @@ public class CloudPlatformSourceScopeRequirement
   @Override
   public Collection<String> getScopes() {
     return ImmutableList.of(
-        "https://www.googleapis.com/auth/projecthosting");
+        "https://www.googleapis.com/auth/source.read_write");
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePassword.java
+++ b/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePassword.java
@@ -102,8 +102,8 @@ public class GoogleRobotUsernamePassword extends BaseStandardCredentials
 
   /**
    * This type of credentials only works for authenticating against
-   * "code.google.com" and "source.developers.google.com" hosted repositories,
-   * for which we require "https".
+   * and "source.developers.google.com" hosted repositories, for which
+   * we require "https".
    */
   @Override
   public boolean matches(List<DomainRequirement> requirements) {

--- a/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordModule.java
+++ b/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordModule.java
@@ -102,9 +102,7 @@ public class GoogleRobotUsernamePasswordModule
     CLOUD_PLATFORM(new Domain("cloud_platform", "",
         ImmutableList.of(
             new SchemeSpecification("https"),
-            new HostnameSpecification(Joiner.on(",").join(
-                "code.google.com",
-                "source.developers.google.com"), "")
+            new HostnameSpecification("source.developers.google.com", "")
         )), new CloudPlatformSourceScopeRequirement()) {
       /** {@inheritDoc} */
       @Override

--- a/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordProvider.java
+++ b/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordProvider.java
@@ -39,7 +39,7 @@ import hudson.security.ACL;
 /**
  * This class automatically wraps existing GoogleRobotCredentials instances
  * into a username password credential type that is compatible with source
- * control plugins like the Git Plugin.  In this way, a 'projecthosting'-scoped
+ * control plugins like the Git Plugin.  In this way, a 'source.read_write'-scoped
  * Oauth credential can be reused for source access to that project's source
  * without manually creating further credentials.
  */

--- a/src/test/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordProviderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordProviderTest.java
@@ -427,50 +427,6 @@ public class GoogleRobotUsernamePasswordProviderTest {
   }
 
   @Test
-  public void testEndToEnd_CloudFlatform() throws Exception {
-    // This is exactly like testEndToEndNoRequirements_CloudPlatform, except it
-    // adds a DomainRequirement that is consistent with the credential type.
-    List<DomainRequirement> requirements =
-        Lists.<DomainRequirement>newArrayList(
-            new HostnameRequirement("code.google.com"),
-            new SchemeRequirement("https")
-        );
-    List<String> expectedCredentialsIds = Lists.newArrayList("foo", "bar");
-    // Quickly sanity-check this behavior or else the mocked return values
-    // proscribed may not reflect reality and we risk infite recursion inside
-    // the implementation class.
-    assertFalse(UsernamePasswordCredentials.class.isAssignableFrom(
-        GoogleRobotCredentials.class));
-    // Proscribe mock behavior.
-    when(fakeProvider.getCredentials(
-        eq(GoogleRobotCredentials.class), eq(Jenkins.getInstance()),
-        eq(ACL.SYSTEM), buildMyDomainRequirementMatcher(
-            ImmutableList.<DomainRequirement>of(
-                new CloudPlatformSourceScopeRequirement()))))
-        .thenReturn(getInputCredentials(expectedCredentialsIds));
-    when(fakeProvider.getCredentials(
-        eq(UsernamePasswordCredentials.class), eq(Jenkins.getInstance()),
-        eq(ACL.SYSTEM), buildMyDomainRequirementMatcher(
-            requirements))).thenReturn(
-        new LinkedList<UsernamePasswordCredentials>());
-
-    assertEquals(getExpectedOutputCredentials(expectedCredentialsIds,
-            GoogleRobotUsernamePasswordModule.Strategy.CLOUD_PLATFORM),
-        CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class,
-            Jenkins.getInstance(), ACL.SYSTEM, requirements));
-
-    verify(fakeProvider).getCredentials(
-        eq(GoogleRobotCredentials.class), eq(Jenkins.getInstance()),
-        eq(ACL.SYSTEM), buildMyDomainRequirementMatcher(
-            ImmutableList.<DomainRequirement>of(
-                new CloudPlatformSourceScopeRequirement())));
-    verify(fakeProvider).getCredentials(
-        eq(UsernamePasswordCredentials.class), eq(Jenkins.getInstance()),
-        eq(ACL.SYSTEM), buildMyDomainRequirementMatcher(requirements));
-    verifyNoMoreInteractions(fakeProvider);
-  }
-
-  @Test
   public void testEndToEnd_Gerrit() throws Exception {
     // This is exactly like testEndToEndNoRequirements_CloudPlatform, except
     // it adds a DomainRequirement that is consistent with the credential type.


### PR DESCRIPTION
The projecthosting scope is deprecated following the shutdown of the
code.google.com service.  Google Cloud Source Repositories uses
the source.read_write (or source.read_only) scope.