### PR TITLE
Fix for deprecated API that breaks plugin in LTS Jenkins versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin(jenkinsVersions: [null, "2.107.1"])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(jenkinsVersions: [null, "2.107.1"])
+buildPlugin(jenkinsVersions: [null, "2.190.1"])

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.5</version>
+    <version>3.6</version>
   </parent>
 
   <!--
@@ -35,7 +35,7 @@
   <url>https://wiki.jenkins.io/display/JENKINS/Google+Source+Plugin</url>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>2.190.1</jenkins.version>
     <java.level>7</java.level>
     <!-- TODO: JodaTime conflicts with the version coming from the optional Git dependency (1.5.1 vs. 2.4)-->
     <enforcer.skip>true</enforcer.skip>
@@ -177,11 +177,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.8.4</version>
@@ -203,6 +198,12 @@
     </dependency>
 
     <!-- plugin dependencies -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>2.6.3</version>
+    </dependency>
+
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.5</version>
+    <version>3.5</version>
   </parent>
 
   <!--
@@ -32,7 +32,16 @@
   <description>
     This plugin exposes a credential for use with the Git plugin for authenticating with Google source code hosting as a service account.
   </description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Google+Source+Plugin</url>
+  <url>https://wiki.jenkins.io/display/JENKINS/Google+Source+Plugin</url>
+
+  <properties>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
+    <!-- TODO: JodaTime conflicts with the version coming from the optional Git dependency (1.5.1 vs. 2.4)-->
+    <enforcer.skip>true</enforcer.skip>
+  </properties>
+
+
   <licenses>
     <license>
       <name>The Apache V2 License</name>
@@ -58,37 +67,19 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <version>1.96</version>
-        <extensions>true</extensions>
-        <configuration>
-          <disabledTestInjection>true</disabledTestInjection>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -109,9 +100,10 @@
         </executions>
       </plugin>
       <plugin>
+        <!-- TODO: switch to the Parent POM's definition once it supports excludeFilterFile -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Medium</threshold>
@@ -187,7 +179,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePassword.java
+++ b/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePassword.java
@@ -143,7 +143,6 @@ public class GoogleRobotUsernamePassword extends BaseStandardCredentials
    * serialize things.
    */
   private boolean areOnMaster() {
-
     return Hudson.getInstanceOrNull() != null;
   }
 

--- a/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePassword.java
+++ b/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePassword.java
@@ -143,7 +143,8 @@ public class GoogleRobotUsernamePassword extends BaseStandardCredentials
    * serialize things.
    */
   private boolean areOnMaster() {
-    return Hudson.getInstance() != null;
+
+    return Hudson.getInstanceOrNull() != null;
   }
 
   /**

--- a/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordModule.java
+++ b/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordModule.java
@@ -23,7 +23,6 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.HostnameSpecification;
 import com.cloudbees.plugins.credentials.domains.SchemeSpecification;
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;

--- a/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordProvider.java
+++ b/src/main/java/com/google/jenkins/plugins/source/GoogleRobotUsernamePasswordProvider.java
@@ -39,7 +39,8 @@ import hudson.security.ACL;
 /**
  * This class automatically wraps existing GoogleRobotCredentials instances
  * into a username password credential type that is compatible with source
- * control plugins like the Git Plugin.  In this way, a 'source.read_write'-scoped
+ * control plugins like the Git Plugin.
+ * In this way, a 'source.read_write'-scoped
  * Oauth credential can be reused for source access to that project's source
  * without manually creating further credentials.
  */


### PR DESCRIPTION
This PR builds on #6 and fixes #7 and #8.

The `getInstance` method is now deprecated and it has been replaced with `getInstanceOrNull`. This PR updates the dependencies so that it can be built and uses the new method for checking if we are on a master node.



