### PR TITLE
Fix project scm URL value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>http://github.com/jenkinsci/${project.artifactId}</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
This causes the update-center to promote an incorrect URL for the SCM of the plugin. This needs to be release to be updated in the next update-center generation.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
